### PR TITLE
Add Default Hotkey For Inserting Page Break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+
+- Added default hotkey for inserting page breaks
+
 ## 1.0.0 - 2025.10.04
 
 ### Added

--- a/main.ts
+++ b/main.ts
@@ -19,6 +19,11 @@ export default class PageBreakPlugin extends Plugin {
 		this.addCommand({
 			id: 'insert-page-break',
 			name: 'Insert page break',
+			// The hotkey is Ctrl+Shift+Enter on Windows and Linux, and Cmd+Shift+Enter on Mac.
+			hotkeys: [{
+				modifiers: ['Mod', 'Shift'],
+				key: 'Enter'
+			}],
 			editorCallback: (editor) => {
 				this.insertPageBreakAtCursor(editor);
 			}


### PR DESCRIPTION
This pull request adds a default hotkey for inserting a page break.

**Windows and Linux:** Ctrl+Shift+Enter
**Mac:** Cmd+Shift+Enter