### PR TITLE
Move Cursor To End Of Page Break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added default hotkey for inserting page breaks
 
+### Fixed
+
+- Fixed the cursor position after inserting page breaks
+
 ## 1.0.0 - 2025.10.04
 
 ### Added

--- a/main.ts
+++ b/main.ts
@@ -10,7 +10,7 @@ export default class PageBreakPlugin extends Plugin {
 			menu.addItem((item) => {
 				item.setTitle('Insert page break')
 					.setIcon('minus')
-					.onClick(() => this.insertPageBreakAtCursor(editor))
+					.onClick(() => this.insertPageBreak(editor))
 					.setSection('page-break');
 			});
 		}));
@@ -25,12 +25,12 @@ export default class PageBreakPlugin extends Plugin {
 				key: 'Enter'
 			}],
 			editorCallback: (editor) => {
-				this.insertPageBreakAtCursor(editor);
+				this.insertPageBreak(editor);
 			}
 		});
 	}
 
-	private insertPageBreakAtCursor(editor: Editor) {
+	private insertPageBreak(editor: Editor) {
 		const cursor = editor.getCursor();
 		const pageBreak =
 			'<div class="page-break"><span class="page-break-label">Page break. An empty line after the break is required.</span></div>\n';

--- a/main.ts
+++ b/main.ts
@@ -35,5 +35,12 @@ export default class PageBreakPlugin extends Plugin {
 		const pageBreak =
 			'<div class="page-break"><span class="page-break-label">Page break. An empty line after the break is required.</span></div>\n';
 		editor.replaceRange(pageBreak, cursor);
+
+		// Move the cursor position to the end of the page break.
+		const endOfPageBreak = {
+			line: cursor.line + 1,
+			ch: 0
+		};
+		editor.setCursor(endOfPageBreak);
 	}
 }


### PR DESCRIPTION
This pull request fixes the bug that would leave the cursor position in front of the page break after inserting one. Now, the cursor position moves to the end of the page break.