### PR TITLE
Add Installation Instructions To README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added default hotkey for inserting page breaks
+- Added installation instructions in `README.md`
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -4,3 +4,13 @@ This is an [Obsidian](https://obsidian.md) plugin for adding page breaks to your
 keeping notes organized. It is especially aimed at notes exported to PDF and then printed on paper.
 
 ![Showcase](./docs/images/plugin-showcase.png)
+
+## Installation
+
+The plugin hasn't been published to Obsidian's community plugins yet. Manual installation is required.
+
+### Manual Installation
+
+1. Download `main.js`, `manifest.json` and `styles.css` from the latest release. See the [releases page](https://github.com/borrelunde/obsidian-plugin-page-break/releases).
+2. Copy the files to the plugin directory `.obsidian/plugins/obsidian-plugin-page-break/` in your vault. 
+3. Reload Obsidian and enable the plugin in **Settings → Community plugins**.


### PR DESCRIPTION
This pull request adds installation instructions to the README.

Since the plugin hasn't been published to Obsidian's community plugins yet, manual installation is the only option covered. 