### PR TITLE
Move Tests To Tests Directory

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,7 @@
 module.exports = {
 	preset: 'ts-jest',
 	testEnvironment: 'node',
-	testMatch: ['**/*.test.ts'],
+	testMatch: ['**/tests/**/*.test.ts'],
 	moduleFileExtensions: ['ts', 'js', 'json'],
 	transform: {
 		'^.+\\.ts$': 'ts-jest',

--- a/tests/PageBreakInserter.test.ts
+++ b/tests/PageBreakInserter.test.ts
@@ -1,4 +1,4 @@
-import {PageBreakInserter} from "./src/PageBreakInserter";
+import {PageBreakInserter} from "../src/PageBreakInserter";
 import {Editor} from "obsidian";
 
 describe('PageBreakInserter', () => {


### PR DESCRIPTION
This pull request moves tests to the tests directory `tests`.

The `testMatch` pattern in `jest.config.js` is updated to reflect the new path for tests.