### PR TITLE
Update Release Workflow To Use PAT_TOKEN Instead Of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,4 +45,4 @@ jobs:
             -   name: Run semantic-release
                 run: npx semantic-release
                 env:
-                    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                    GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
This pull request replaces the `GITHUB_TOKEN` in the "Run semantic-release" step of the release workflow with `PAT_TOKEN`. The `PAT_TOKEN` is a token for semantic-release to bypass branch protection so that it can commit changes when updating versions and writing changelog.