### PR TITLE
Update Release Workflow To Use PAT_TOKEN For Checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
                 uses: actions/checkout@v4
                 with:
                     fetch-depth: '0'
+                    token: ${{ secrets.PAT_TOKEN }}
 
             # Set up Node.js 20 because NPM is used in the next steps.
             -   name: Use Node.js 20


### PR DESCRIPTION
This pull request adds the `PAT_TOKEN` to the checkout step so that `git push` can bypass branch protection.