### PR TITLE
Fix Release Workflow To Update manifest.json Version

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -21,7 +21,7 @@
 		[
 			"@semantic-release/exec",
 			{
-				"prepareCmd": "node version-bump.mjs && echo '${nextRelease.notes}' > RELEASE_NOTES.md"
+				"prepareCmd": "node version-bump.mjs ${nextRelease.version} && echo '${nextRelease.notes}' > RELEASE_NOTES.md"
 			}
 		],
 		[

--- a/version-bump.mjs
+++ b/version-bump.mjs
@@ -1,6 +1,14 @@
 import { readFileSync, writeFileSync } from "fs";
 
-const targetVersion = process.env.npm_package_version;
+// Prioritize command-line argument (from semantic-release) over npm environment variable.
+const targetVersion = process.argv[2] || process.env.npm_package_version;
+
+if (!targetVersion) {
+	console.error("Error: No version provided.");
+	console.error("Usage: node version-bump.mjs <version>");
+	console.error("Or run via npm script where npm_package_version is set.");
+	process.exit(1);
+}
 
 // Read minAppVersion from manifest.json and bump the version to the target version.
 const manifest = JSON.parse(readFileSync("manifest.json", "utf8"));


### PR DESCRIPTION
This pull request changes the version-bump script to accept a version generated by semantic-release. Used in the release workflow.